### PR TITLE
Use toFixed to get rid of the scientific notation.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export function parse(uri) {
         const amountKey = obj.function_name === 'transfer' ? 'uint256' : 'value';
 
         if(obj.parameters[amountKey]) {
-            obj.parameters[amountKey] = new BigNumber(obj.parameters[amountKey], 10).toString();
+            obj.parameters[amountKey] = new BigNumber(obj.parameters[amountKey], 10).toFixed();
             if (!isFinite(obj.parameters[amountKey])) throw new Error('Invalid amount')
             if (obj.parameters[amountKey] < 0) throw new Error('Invalid amount')
         }


### PR DESCRIPTION
Hi @brunobar79 ,

This is a small fix to ensure that we convert the amount into a string, without the scientific notation.

Currently **1.234e21** becomes **1.234e+21**.
After the fix it will be **1234000000000000000000**.

Cheers,
Tamas