### PR TITLE
fix: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
   },
   "resolutions": {
     "**/trim": "0.0.3"
+  },
+  "homepage": "https://github.com/brunobar79/eth-url-parser#readme",
+  "bugs": {
+    "url": "https://github.com/brunobar79/eth-url-parser/issues"
   }
 }


### PR DESCRIPTION
Adds standard npm metadata links to `package.json`:

- `homepage` points to the repository README
- `bugs.url` points to the GitHub issue tracker

This matches the existing public repository and makes `npm view eth-url-parser homepage bugs --json` expose the same package support links users expect from npm metadata.

Verification:

```sh
node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('eth-url-parser package json valid')"
npm pack --dry-run --json --ignore-scripts
```

Metadata-only change; no runtime behavior changes.